### PR TITLE
Add missing SQLite interop configuration to .csproj file

### DIFF
--- a/c#/Backend.IntegrationTests/Backend.IntegrationTests.csproj
+++ b/c#/Backend.IntegrationTests/Backend.IntegrationTests.csproj
@@ -108,4 +108,10 @@
   <Import Project="..\packages\EntityFramework.6.3.0\build\EntityFramework.targets" Condition="Exists('..\packages\EntityFramework.6.3.0\build\EntityFramework.targets')" />
   <Import Project="..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.113.3\build\net45\Stub.System.Data.SQLite.Core.NetFramework.targets" Condition="Exists('..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.113.3\build\net45\Stub.System.Data.SQLite.Core.NetFramework.targets')" />
   <Import Project="..\packages\System.Data.SQLite.Core.1.0.108.0\build\net45\System.Data.SQLite.Core.targets" Condition="Exists('..\packages\System.Data.SQLite.Core.1.0.108.0\build\net45\System.Data.SQLite.Core.targets')" />
+  <PropertyGroup>
+    <ContentSQLiteInteropFiles>true</ContentSQLiteInteropFiles>
+    <CopySQLiteInteropFiles>false</CopySQLiteInteropFiles>
+    <CleanSQLiteInteropFiles>false</CleanSQLiteInteropFiles>
+    <CollectSQLiteInteropFiles>false</CollectSQLiteInteropFiles>
+  </PropertyGroup>
 </Project>

--- a/c#/Backend.IntegrationTests/Persistence/CountryAggregateManagerTests.cs
+++ b/c#/Backend.IntegrationTests/Persistence/CountryAggregateManagerTests.cs
@@ -1,7 +1,10 @@
 ﻿using Backend.Application.Countries.Interfaces;
 using Backend.Persistence;
 using NUnit.Framework;
+using System;
+using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 
 namespace Backend.IntegrationTests.Persistence
@@ -9,6 +12,15 @@ namespace Backend.IntegrationTests.Persistence
     public class CountryAggregateManagerTests
     {
         private ICountryAggregateManager dbManager;
+
+        [OneTimeSetUp]
+        public void SetUpBaseDirectory()
+        {
+            // When executing the integration tests, the current directory changes to C:\Users\<USER>\AppData\Local\Temp
+            var assemblyDir = AppDomain.CurrentDomain.BaseDirectory;
+            Directory.SetCurrentDirectory(assemblyDir);
+            Environment.CurrentDirectory = assemblyDir;
+        }
 
         [SetUp]
         public void SetUpDependencies()

--- a/c#/Backend.IntegrationTests/app.config
+++ b/c#/Backend.IntegrationTests/app.config
@@ -27,6 +27,7 @@
   </system.data>
   <connectionStrings>
     <clear />
-    <add name="SQLiteConnectionString" providerName="System.Data.SQLite" connectionString="Data Source=Backend.IntegrationTests\\Persistence\\testdb.db;Version=3;FailIfMissing=True" />
+    <!--the connection string is relative to Backend.IntegrationTests\Debug\bin-->
+    <add name="SQLiteConnectionString" providerName="System.Data.SQLite" connectionString="Data Source=..\..\\Persistence\\testdb.db;Version=3;FailIfMissing=True" />
   </connectionStrings>
 </configuration>


### PR DESCRIPTION
This PR fixes the following issues:
1.  The 'Copy' and 'Delete' tasks for the interop file `SQLite.Interop.dll` do not work properly. This results in the `SQLite.Interop.dll` not being copied to `Backend.IntegrationTests\bin\Debug`.
The issue is logged [here](http://system.data.sqlite.org/index.html/tktview/db7a713f4f0ad2b4f96520aa9782e38040f5f166)
The issue fix is described [here](http://system.data.sqlite.org/index.html/info/2ed3cad9cc9d5938808816bbc6da92366cd5a4dc).
Instead of creating  `.user` file, this PR adds the instructions directly to the `.csproj` file.

2. When the integration tests are executed, the base directory changes to `C:\Users\<USER>\AppData\Local\Temp`. This leads to a malformed connection string. To fix this, the base path is always set to `Backend.IntegrationTests\bin\Debug` and the path to `testdb.db` is relative to that folder.